### PR TITLE
Fix NoSuchFieldException: MAINHAND crash on load

### DIFF
--- a/src/main/java/draylar/tiered/data/AttributeDataLoader.java
+++ b/src/main/java/draylar/tiered/data/AttributeDataLoader.java
@@ -9,6 +9,7 @@ import draylar.tiered.api.PotentialAttribute;
 import draylar.tiered.gson.EntityAttributeModifierDeserializer;
 import draylar.tiered.gson.EntityAttributeModifierSerializer;
 import draylar.tiered.gson.EquipmentSlotDeserializer;
+import draylar.tiered.gson.EquipmentSlotSerializer;
 import net.minecraft.entity.EquipmentSlot;
 import net.minecraft.entity.attribute.EntityAttributeModifier;
 import net.minecraft.resource.JsonDataLoader;
@@ -29,6 +30,7 @@ public class AttributeDataLoader extends JsonDataLoader {
             .disableHtmlEscaping()
             .registerTypeAdapter(EntityAttributeModifier.class, new EntityAttributeModifierDeserializer())
             .registerTypeAdapter(EntityAttributeModifier.class, new EntityAttributeModifierSerializer())
+            .registerTypeAdapter(EquipmentSlot.class, new EquipmentSlotSerializer())
             .registerTypeAdapter(EquipmentSlot.class, new EquipmentSlotDeserializer())
             .registerTypeHierarchyAdapter(Style.class, new Style.Serializer())
             .create();

--- a/src/main/java/draylar/tiered/gson/EquipmentSlotSerializer.java
+++ b/src/main/java/draylar/tiered/gson/EquipmentSlotSerializer.java
@@ -1,0 +1,13 @@
+package draylar.tiered.gson;
+
+import com.google.gson.*;
+import net.minecraft.entity.EquipmentSlot;
+
+import java.lang.reflect.Type;
+
+public class EquipmentSlotSerializer implements JsonSerializer<EquipmentSlot> {
+	@Override
+	public JsonElement serialize(EquipmentSlot src, Type typeOfSrc, JsonSerializationContext context) {
+		return new JsonPrimitive(src.name());
+	}
+}


### PR DESCRIPTION
Fixes #26.

My guess as to what's happening:
Gson wants to ultimately serialize `EquipmentSlot` here
https://github.com/Draylar/tiered/blob/cbaf6f6e4eb8f31b4e3006f8c1537c822cf99ac6/src/main/java/draylar/tiered/Tiered.java#L109
and by default uses the [EnumTypeAdapter](https://github.com/google/gson/blob/ceae88bd6667f4263bbe02e6b3710b8a683906a2/gson/src/main/java/com/google/gson/internal/bind/TypeAdapters.java#L777-L794).
This specifically runs
```
          String name = constant.name();
          SerializedName annotation = classOfT.getField(name).getAnnotation(SerializedName.class);
```
So `classOfT.getField(name)` searches for the field `MAINHAND` inside the class `EquipmentSlot`.

What's the issue? Obfuscation.
There is no field with the name `MAINHAND`, but it's `field_6173` (in intermediary).

The fix is to add a straight forward serializer for the enum.